### PR TITLE
nzbget 17.0 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,33 +3,13 @@ FROM ubuntu:16.04
 MAINTAINER chris turra <cturra@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV VERSION         16.4
 
 # grab/install everything required to compile and launch nzbget.
 RUN echo "deb http://us.archive.ubuntu.com/ubuntu xenial main multiverse" >> /etc/apt/sources.list \
  && apt-get -q update                  \
- && apt-get -y install build-essential \
-                       libncurses5-dev \
-                       libssl-dev      \
-                       libxml2-dev     \
-                       unrar           \
+ && apt-get -y install unrar           \
                        wget            \
  && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /tmp
-
-# download/install/config nzbget
-RUN wget -O /tmp/nzbget.tar.gz                                                                          \
-         -q https://github.com/nzbget/nzbget/releases/download/v${VERSION}/nzbget-${VERSION}-src.tar.gz \
- && tar -xf nzbget.tar.gz \
- && rm -f nzbget.tar.gz   \
- && cd nzbget-${VERSION}  \
- && sh configure --with-tlslib=OpenSSL                                         \
-                 --with-libxml2-includes=/usr/include/libxml2                  \
-                 --with-libxml2-libraries=/usr/lib/x86_64-linux-gnu/libxml2.so \
- && make                                                                       \
- && make install                                                               \
- && rm -rf /tmp/nzbget-${VERSION}
 
 # copy startup script
 COPY assets/startup.sh /opt/startup.sh

--- a/README.md
+++ b/README.md
@@ -11,50 +11,45 @@ If you're running this container for the first time, the default login details a
  * pass: tegbzn6789
 
 
-Building the container
+Running from Docker Hub
 ---
-Before building, there are two locations to verify variable to ensure is correct
-for your setup.
-
-1) In the `Dockerfile`, check:
-
-* VERSION - version of NZBGet that will be fetched
-
-2) In `vars` check:
-
-* `NZBGET_VERSION` - version of NZBGet that will be tagged
-* `EXT_DATA_DIR` - location on your hosts filesystem to mount the nzbget
-application (data) directory.
-* `EXT_DOWNLOAD_DIR` - location on your hosts filesystem to mount the
-nzbget download directory (could be within the data directory).
-* `EXT_NZBGET_PORT` - tcp port to bind nzbget to on the docker host
-* `INT_NZBGET_PORT` - tcp port to bind nzbget to INSIDE the docker container
-
-With this configured correctly for your setup, the following Docker build
-command will create the container image manually. Or, below that, an example
-of how you can run the `build.sh` script.
+Pull and run -- it's this simple.
 
 ```
-$ docker build -t cturra/nzbget .
+# pull from docker hub
+$> docker pull cturra/nzbget
 
-```
-OR
-```
-$ ./build.sh
+# run nzbget
+docker run --name=nzbget --restart=always --detach=true    \
+              --env=NZBGET_TRACK=stable                    \
+              --volume=/path/to/data/:/data                \
+              --volume=/path/to/downloads/:/data/downloads \
+              --publish=6789:6789 cturra/nzbget
 ```
 
-Running the container
+Building and Running with Docker Compose
 ---
-The following example Docker run command mounts one volume, used to persistently
-store the NZBGet data (configurations, etc). Or, you can use the `run.sh` script
-which will load the appropriate environment details from the `vars` file and launch
-your nzbget container.
+Using the docker-compose.yml file included in this git repo, you can build the container yourself (should you choose to).
 
 ```
-$ docker run --name=nzbget -v /data/nzbget:/data:rw -p 6789:6789 -d cturra/nzbget
+# build nzbget
+$> docker-compose build nzbget
+
+# run nzbget
+$> docker-compose up -d nzbget
+
+# (optional) check the logs
+$> docker-compose logs nzbget
 ```
 
-OR
+Building and Running with Docker Engine
+---
+Using the vars file in this git repo, you can update any of the variables to reflect your environment. Once updated, simply execute the build then run scripts.
+
 ```
-$ ./run.sh
+# build nzbget
+$> ./build.sh
+
+# run nzbget
+$> ./run.sh
 ```

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This container runs a NZBGet Usenet downloader. More about NZBGet can be found a
 
 If you're running this container for the first time, the default login details are:
 
- * user: nzbget
- * pass: tegbzn6789
+ * user: `nzbget`
+ * pass: `tegbzn6789`
 
 
 Running from Docker Hub
@@ -20,11 +20,12 @@ Pull and run -- it's this simple.
 $> docker pull cturra/nzbget
 
 # run nzbget
-docker run --name=nzbget --restart=always --detach=true    \
-              --env=NZBGET_TRACK=stable                    \
-              --volume=/path/to/data/:/data                \
-              --volume=/path/to/downloads/:/data/downloads \
-              --publish=6789:6789 cturra/nzbget
+$> docker run --name=nzbget --restart=always --detach=true  \
+              --env=NZBGET_TRACK=stable                     \
+              --publish=6789:6789                           \
+              --volume=/path/to/data/:/data                 \
+              --volume=/path/to/downloads/:/data/downloads  \
+              cturra/nzbget
 ```
 
 Building and Running with Docker Compose

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -1,17 +1,53 @@
 #!/bin/bash
 
+WGET=$(which wget)
+
+# do we want the stable or testing track?
+if [ ! -z "${NZBGET_TRACK}" ]; then
+  if [ ${NZBGET_TRACK} == "stable" ]; then
+    echo "[INFO] Choosing the NZBGet stable branch."
+  elif [ "${NZBGET_TRACK}" == "testing" ]; then
+    echo "[INFO] Choosing the NZBGet testing branch."
+  fi
+
+# if NZBGET_TRACK environment variable is not set, choose stable
+else
+  echo "[INFO] NZBGET_TRACK environment variable unset. Auto selecting stable."
+  export NZBGET_TRACK=stable
+fi
+
+# get stable release version from nzbget.com
+NZBGET_DOWNLOAD_URL=$( $WGET --quiet                                                     \
+                             --output-document                                           \
+                             - http://nzbget.net/info/nzbget-version-linux.json         |\
+                       sed --quiet "s/^.*${NZBGET_TRACK}-download.*: \"\(.*\)\".*/\1/p"
+                     )
+
+# download NZBGet
+echo "[INFO] Downloading NZBGet from $NZBGET_DOWNLOAD_URL"
+$WGET --no-check-certificate            \
+      --output-document /tmp/nzbget.run \
+      --quiet                           \
+      ${NZBGET_DOWNLOAD_URL}            \
+
+# run the installer
+if [ -f /tmp/nzbget.run ]; then
+  sh /tmp/nzbget.run
+fi
+
 # check if config is present in /data directory. if not, lets
 # use the default config shipped with nzbget.
 if [ ! -f /data/nzbget.conf ]; then
-  cp /usr/local/share/nzbget/nzbget.conf /data/nzbget.conf
+  echo "[INFO] Copying config into /data/nzbget.conf"
+  cp /nzbget/nzbget.conf /data/nzbget.conf
 fi
 
 # remove .lock file if it's present
 if [ -f /data/nzbget.lock ]; then
-  rm -f /data/nzbget.lock
+  rm --force /data/nzbget.lock
 fi
 
 # start nzbget
-/usr/local/bin/nzbget --configfile /data/nzbget.conf \
-                      --option OutputMode=log        \
-                      --server
+/nzbget/nzbget --configfile /data/nzbget.conf \
+               --option OutputMode=log        \
+               --server

--- a/build.sh
+++ b/build.sh
@@ -5,8 +5,5 @@ source vars
 
 DOCKER=$(which docker)
 
-# build image and tag with build tag (MonthDayYearMinute)
-$DOCKER build --pull -t ${IMAGE_NAME}:${NZBGET_VERSION} .
-
-# add latest tag
-$DOCKER tag ${IMAGE_NAME}:${NZBGET_VERSION} ${IMAGE_NAME}:latest
+# build image
+$DOCKER build --pull --tag ${IMAGE_NAME} .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '2'
+
+services:
+  nzbget:
+    build: .
+    image: cturra/nzbget:latest
+    container_name: nzbget
+    restart: always
+    environment:
+      - NZBGET_TRACK=stable
+    ports:
+      - 6789:6789
+    volumes:
+      - /data/nzbget:/data
+      - /data/downloads:/data/downloads

--- a/run.sh
+++ b/run.sh
@@ -15,6 +15,7 @@ function start_container() {
   $DOCKER run --name=${CONTAINER_NAME}                        \
               --restart=always                                \
               --detach=true                                   \
+              --env=NZBGET_TRACK=${NZBGET_TRACK}              \
               --volume=${EXT_DATA_DIR}:/data                  \
               --volume=${EXT_DOWNLOAD_DIR}:/data/downloads    \
               --publish=${EXT_NZBGET_PORT}:${INT_NZBGET_PORT} \

--- a/vars
+++ b/vars
@@ -6,13 +6,16 @@
 IMAGE_NAME="cturra/nzbget"
 CONTAINER_NAME="nzbget"
 
-NZBGET_VERSION="16.4"
+# NZBGet Track:
+# - stable
+# - testing
+NZBGET_TRACK="stable"
 
 # nzbget application directory on docker host
 EXT_DATA_DIR="/data/nzbget"
 
 # nzbget download directory on docker host
-EXT_DOWNLOAD_DIR="/data/downloads/usenet"
+EXT_DOWNLOAD_DIR="/data/downloads"
 
 # nzbget port on docker host
 EXT_NZBGET_PORT=6789


### PR DESCRIPTION
this release moves away from compiling and implements the packaged installer. on startup, the container will retreive the latest from either the stable or testing branch based on the `ENV` variable provided. future upgrades _should_ simply require container restarts.
