### PR TITLE
moving to --no-cache flag instead of manually update/delete cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
 FROM alpine:latest
 
 # grab/install everything required for nzbget.
-RUN apk update    \
- && apk add p7zip \
-            unrar \
-            wget  \
- && rm -rf /var/cache/apk/*
+RUN apk add --no-cache p7zip \
+                       unrar \
+                       wget
 
 # copy startup script
 COPY assets/startup.sh /opt/startup.sh


### PR DESCRIPTION
See [alpine usage](https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache):

> As of Alpine Linux 3.3 there exists a new `--no-cache` option for `apk`. It allows users to install packages with an index that is updated and used on-the-fly and not cached locally:
> 
> [...]
> 
> This avoids the need to use `--update` and remove `/var/cache/apk/*` when done installing packages.

Current `alpine:latest` version is 3.7.